### PR TITLE
Polling updates: jitter and notification improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,4 +85,4 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0

--- a/config.go
+++ b/config.go
@@ -55,6 +55,12 @@ type SchemaWatcherConfig struct {
 	// return an error. If unset and left zero, a default period of 5 minutes
 	// is used.
 	PollingPeriod time.Duration
+	// A number between 0 and 1 that represents the amount of jitter to add to
+	// the polling period. A value of zero means no jitter. A value of one means
+	// up to 100% jitter, so the actual period would be between 0 and 2*PollingPeriod.
+	// To prevent self-synchronization (and thus thundering herds) when there are
+	// multiple pollers, a value of 0.1 to 0.3 is typical.
+	Jitter float64
 	// If Cache is non-nil, it is used for increased robustness, even in the
 	// face of the remote schema registry being unavailable. If non-nil and the
 	// API call to initially retrieve a schema fails, the schema will instead
@@ -63,11 +69,14 @@ type SchemaWatcherConfig struct {
 	// restarted and the remote registry is unavailable, the latest cached schema
 	// can still be used.
 	Cache Cache
-	// OnUpdate is an optional callback that will be invoked when a schema is
-	// fetched. This can be used by an application to take action when a new
-	// schema becomes available. It is possible that the previous and newly
-	// fetched schema are the same.
+	// OnUpdate is an optional callback that will be invoked when a new schema
+	// is fetched. This can be used by an application to take action when a new
+	// schema becomes available.
 	OnUpdate func()
+	// OnError is an optional callback that will be invoked when a schema cannot
+	// be fetched. This could be due to the SchemaPoller returning an error or
+	// failure to convert the fetched descriptors into a resolver.
+	OnError func(error)
 }
 
 func (c *SchemaWatcherConfig) validate() error {

--- a/jitter.go
+++ b/jitter.go
@@ -1,0 +1,64 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prototransform
+
+import (
+	"hash/maphash"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// We create our own locked RNG so we won't have lock contention with the global
+// RNG that package "math/rand" creates. Also, that way we are not at the mercy
+// of other packages that might be seeding "math/rand"'s global RNG in a bad way.
+var rnd = newLockedRand()
+
+func addJitter(period time.Duration, jitter float64) time.Duration {
+	factor := (rnd.Float64()*2 - 1) * jitter // produces a number between -jitter and jitter
+	period = time.Duration(float64(period) * (factor + 1))
+	if period == 0 {
+		period = 1 // ticker.Reset panics if duration is zero
+	}
+	return period
+}
+
+type lockedSource struct {
+	mu  sync.Mutex
+	src rand.Source
+}
+
+func (s *lockedSource) Int63() int64 {
+	s.mu.Lock()
+	i := s.src.Int63()
+	s.mu.Unlock()
+	return i
+}
+
+func (s *lockedSource) Seed(seed int64) {
+	s.mu.Lock()
+	s.src.Seed(seed)
+	s.mu.Unlock()
+}
+
+func newLockedRand() *rand.Rand {
+	return rand.New(&lockedSource{src: rand.NewSource(int64(seed()))})
+}
+
+func seed() uint64 {
+	// lock-free and fast; under-the-hood calls runtime.fastrand
+	// https://www.reddit.com/r/golang/comments/ntyi7i/comment/h0w0tu7/
+	return new(maphash.Hash).Sum64()
+}

--- a/jitter_test.go
+++ b/jitter_test.go
@@ -1,0 +1,78 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prototransform
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddJitter(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name          string
+		pollingPeriod time.Duration
+		jitter        float64
+		min, max      time.Duration
+	}{
+		{
+			name:          "no jitter",
+			pollingPeriod: time.Minute,
+			jitter:        0,
+			min:           time.Minute,
+			max:           time.Minute,
+		},
+		{
+			name:          "100% jitter",
+			pollingPeriod: 3 * time.Minute,
+			jitter:        1,
+			min:           1,
+			max:           6 * time.Minute,
+		},
+		{
+			name:          "25% jitter",
+			pollingPeriod: 4 * time.Second,
+			jitter:        0.25,
+			min:           3 * time.Second,
+			max:           5 * time.Second,
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			var min, max time.Duration
+			for i := 0; i < 10_000; i++ {
+				p := addJitter(testCase.pollingPeriod, testCase.jitter)
+				require.GreaterOrEqual(t, p, testCase.min)
+				require.LessOrEqual(t, p, testCase.max)
+				if i == 0 || p < min {
+					min = p
+				}
+				if i == 0 || p > max {
+					max = p
+				}
+			}
+			// After 10k iterations, with uniform distribution RNG, we could
+			// probably put much tighter bound on this; but we're a bit lenient
+			// to make sure we don't see flaky failures in CI. We want to observe
+			// at least 90% of the effective jitter range.
+			minVariation := time.Duration(0.9 * float64(testCase.max-testCase.min))
+			require.GreaterOrEqual(t, max-min, minVariation)
+		})
+	}
+}

--- a/schema_watcher.go
+++ b/schema_watcher.go
@@ -21,10 +21,12 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -51,17 +53,20 @@ type SchemaWatcher struct {
 	schemaID       string
 	includeSymbols []string
 	cacheKey       string
+	resolveNow     chan struct{}
 
 	// used to prevent concurrent calls to cache.Save, which could
 	// otherwise potentially result in a known-stale value in the cache.
 	cacheMu sync.Mutex
 	cache   Cache
 
-	callbackMu sync.Mutex
-	callback   func()
+	callbackMu  sync.Mutex
+	callback    func()
+	errCallback func(error)
 
 	resolverMu      sync.RWMutex
 	resolver        Resolver
+	resolvedSchema  *descriptorpb.FileDescriptorSet
 	resolveTime     time.Time
 	resolvedVersion string
 	// if nil, watcher has been stopped; if not nil, will be called
@@ -147,11 +152,13 @@ func NewSchemaWatcher(ctx context.Context, config *SchemaWatcherConfig) (*Schema
 		includeSymbols: syms,
 		cacheKey:       cacheKey,
 		callback:       config.OnUpdate,
+		errCallback:    config.OnError,
 		cache:          config.Cache,
 		stop:           cancel,
 		resolverReady:  make(chan struct{}),
+		resolveNow:     make(chan struct{}, 1),
 	}
-	schemaWatcher.start(ctx, pollingPeriod)
+	schemaWatcher.start(ctx, pollingPeriod, config.Jitter)
 	return schemaWatcher, nil
 }
 
@@ -161,31 +168,85 @@ func (s *SchemaWatcher) getResolver() Resolver {
 	return s.resolver
 }
 
-func (s *SchemaWatcher) updateResolver(ctx context.Context, fallbackToCache bool) error {
-	schema, schemaVersion, schemaTs, err := s.getFileDescriptorSet(ctx, fallbackToCache)
+func (s *SchemaWatcher) updateResolver(ctx context.Context) (err error) {
+	var changed bool
+	if s.callback != nil || s.errCallback != nil {
+		// make sure to invoke callback at the end to notify application
+		defer func() {
+			if changed && s.callback != nil {
+				go func() {
+					// Lock forces sequential calls to callback and also
+					// means callback does not need to be thread-safe.
+					s.callbackMu.Lock()
+					defer s.callbackMu.Unlock()
+					s.callback()
+				}()
+			} else if !errors.Is(err, ErrSchemaNotModified) && s.errCallback != nil {
+				go func() {
+					s.callbackMu.Lock()
+					defer s.callbackMu.Unlock()
+					s.errCallback(err)
+				}()
+			}
+		}()
+	}
+
+	schema, schemaVersion, schemaTs, err := s.getFileDescriptorSet(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to fetch schema: %w", err)
 	}
-	resolver, err := newResolver(schema)
+
+	s.resolverMu.RLock()
+	prevSchema, prevTimestamp := s.resolvedSchema, s.resolveTime
+	s.resolverMu.RUnlock()
+
+	if prevSchema != nil {
+		if schemaTs.Before(prevTimestamp) {
+			// Only possible if schemaTs is loaded from cache entry that is
+			// older than last successful load. If that happens, just leave
+			// the existing resolver in place.
+			return nil
+		}
+		if proto.Equal(prevSchema, schema) {
+			// nothing changed
+			return nil
+		}
+	}
+
+	files, resolver, err := newResolver(schema)
 	if err != nil {
 		return fmt.Errorf("unable to create resolver from schema: %w", err)
 	}
+
+	if len(s.includeSymbols) > 0 {
+		var missingSymbols []string
+		for _, sym := range s.includeSymbols {
+			_, err := files.FindDescriptorByName(protoreflect.FullName(sym))
+			if err != nil {
+				missingSymbols = append(missingSymbols, sym)
+			}
+		}
+		if len(missingSymbols) > 0 {
+			sort.Strings(missingSymbols)
+			for i, sym := range missingSymbols {
+				missingSymbols[i] = strconv.Quote(sym)
+			}
+			return fmt.Errorf("schema poller returned incomplete schema: missing %v", strings.Join(missingSymbols, ", "))
+		}
+	}
+
 	s.resolverMu.Lock()
 	defer s.resolverMu.Unlock()
-	if schemaTs.Before(s.resolveTime) {
-		// Only possible if schemaTs is loaded from cache entry that is
-		// older than last successful load. If that happens, just leave
-		// the existing resolver in place.
-		return nil
-	}
 	s.resolver = resolver
 	s.resolveTime = schemaTs
-	s.resolverErr = nil
+	s.resolvedSchema = schema
 	s.resolvedVersion = schemaVersion
+	s.resolverErr = nil
+	changed = true
 	return nil
 }
 
-func (s *SchemaWatcher) initialUpdateResolver(ctx context.Context, pollingPeriod time.Duration) (success bool) {
+func (s *SchemaWatcher) initialUpdateResolver(ctx context.Context, pollingPeriod time.Duration, jitter float64) (success bool) {
 	defer func() {
 		s.resolverMu.Lock()
 		defer s.resolverMu.Unlock()
@@ -198,7 +259,7 @@ func (s *SchemaWatcher) initialUpdateResolver(ctx context.Context, pollingPeriod
 
 	var delay time.Duration
 	for {
-		err := s.updateResolver(ctx, true)
+		err := s.updateResolver(ctx)
 		if err == nil {
 			// success!
 			return true
@@ -210,10 +271,12 @@ func (s *SchemaWatcher) initialUpdateResolver(ctx context.Context, pollingPeriod
 			// immediately retry, but delay 1s if it fails again
 			delay = time.Second
 		} else {
+			timer := time.NewTimer(addJitter(delay, jitter))
 			select {
 			case <-ctx.Done():
+				timer.Stop()
 				return false
-			case <-time.After(delay):
+			case <-timer.C:
 			}
 			delay = delay * 2 // exponential backoff
 		}
@@ -285,6 +348,16 @@ func (s *SchemaWatcher) LastResolved() (bool, time.Time) {
 	return true, s.resolveTime
 }
 
+// ResolveNow tells the watcher to poll for a new schema immediately instead of
+// waiting until the next scheduled time per the configured polling period.
+func (s *SchemaWatcher) ResolveNow() {
+	select {
+	case s.resolveNow <- struct{}{}:
+	default:
+		// channel buffer is full, which means "resolve now" signal already pending
+	}
+}
+
 // FindExtensionByName looks up an extension field by the field's full name.
 // Note that this is the full name of the field as determined by
 // where the extension is declared and is unrelated to the full name of the
@@ -335,22 +408,42 @@ func (s *SchemaWatcher) FindMessageByURL(url string) (protoreflect.MessageType, 
 	return res.FindMessageByURL(url)
 }
 
-func (s *SchemaWatcher) start(ctx context.Context, pollingPeriod time.Duration) {
+func (s *SchemaWatcher) start(ctx context.Context, pollingPeriod time.Duration, jitter float64) {
 	go func() {
-		if !s.initialUpdateResolver(ctx, pollingPeriod) {
+		if !s.initialUpdateResolver(ctx, pollingPeriod, jitter) {
 			return
 		}
 		defer s.Stop()
-		ticker := time.NewTicker(pollingPeriod)
+		period := pollingPeriod
+		if jitter != 0 {
+			period = addJitter(pollingPeriod, jitter)
+		}
+		ticker := time.NewTicker(period)
 		defer ticker.Stop()
 		for {
+			// consume any "resolve now" signal that arrived while we were concurrently resolving
+			select {
+			case <-s.resolveNow:
+			default:
+			}
+
 			select {
 			case <-ticker.C:
 				if ctx.Err() != nil {
 					// don't bother fetching a schema if context is done
 					return
 				}
-				_ = s.updateResolver(ctx, false)
+				if jitter != 0 {
+					period = addJitter(pollingPeriod, jitter)
+					ticker.Reset(period)
+				}
+				_ = s.updateResolver(ctx)
+			case <-s.resolveNow:
+				if ctx.Err() != nil {
+					// don't bother fetching a schema if context is done
+					return
+				}
+				_ = s.updateResolver(ctx)
 			case <-ctx.Done():
 				return
 			}
@@ -375,15 +468,14 @@ func (s *SchemaWatcher) IsStopped() bool {
 	return s.stop == nil
 }
 
-func (s *SchemaWatcher) getFileDescriptorSet(ctx context.Context, fallbackToCache bool) (*descriptorpb.FileDescriptorSet, string, time.Time, error) {
+func (s *SchemaWatcher) getFileDescriptorSet(ctx context.Context) (*descriptorpb.FileDescriptorSet, string, time.Time, error) {
 	s.resolverMu.RLock()
 	currentVersion := s.resolvedVersion
 	s.resolverMu.RUnlock()
 	descriptors, version, err := s.poller.GetSchema(ctx, s.includeSymbols, currentVersion)
 	respTime := time.Now()
-
 	if err != nil {
-		if errors.Is(err, ErrSchemaNotModified) || s.cache == nil || !fallbackToCache {
+		if errors.Is(err, ErrSchemaNotModified) || s.cache == nil {
 			return nil, "", time.Time{}, err
 		}
 		// try to fallback to cache
@@ -400,15 +492,6 @@ func (s *SchemaWatcher) getFileDescriptorSet(ctx context.Context, fallbackToCach
 			return nil, "", time.Time{}, err
 		}
 		return msg.GetSchema().GetDescriptors(), msg.GetSchema().GetVersion(), msg.GetSchemaTimestamp().AsTime(), nil
-	}
-	if s.callback != nil {
-		go func() {
-			// Lock forces sequential calls to callback and also
-			// means callback does not need to be thread-safe.
-			s.callbackMu.Lock()
-			defer s.callbackMu.Unlock()
-			s.callback()
-		}()
 	}
 	if s.cache != nil {
 		go func() {
@@ -441,18 +524,15 @@ func (s *SchemaWatcher) getFileDescriptorSet(ctx context.Context, fallbackToCach
 // If the input slice is empty, this returns nil
 // The given FileDescriptors must be self-contained, that is they must contain all imports.
 // This can NOT be guaranteed for FileDescriptorSets given over the wire, and can only be guaranteed from builds.
-func newResolver(fileDescriptors *descriptorpb.FileDescriptorSet) (Resolver, error) {
+func newResolver(fileDescriptors *descriptorpb.FileDescriptorSet) (*protoregistry.Files, Resolver, error) {
 	// TODO(TCN-925): probably needs to reparse unrecognized fields after it creates a resolver.
 	if len(fileDescriptors.File) == 0 {
-		return (*protoregistry.Types)(nil), nil
+		return nil, (*protoregistry.Types)(nil), nil
 	}
-	files, err := protodesc.FileOptions{
-		AllowUnresolvable: true,
-	}.NewFiles(
-		fileDescriptors,
-	)
+	files, err := protodesc.FileOptions{AllowUnresolvable: true}.
+		NewFiles(fileDescriptors)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	types := &protoregistry.Types{}
 	var rangeErr error
@@ -464,9 +544,9 @@ func newResolver(fileDescriptors *descriptorpb.FileDescriptorSet) (Resolver, err
 		return true
 	})
 	if rangeErr != nil {
-		return nil, rangeErr
+		return nil, nil, rangeErr
 	}
-	return types, nil
+	return files, types, nil
 }
 
 type typeContainer interface {

--- a/schema_watcher_test.go
+++ b/schema_watcher_test.go
@@ -156,7 +156,7 @@ func TestSchemaWatcher_getFileDescriptorSet(t *testing.T) {
 	s := &SchemaWatcher{
 		poller: NewSchemaPoller(newFakeFileDescriptorSetService(), "", ""),
 	}
-	got, version, _, err := s.getFileDescriptorSet(context.Background(), false)
+	got, version, _, err := s.getFileDescriptorSet(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.NotEmpty(t, version)
@@ -164,7 +164,7 @@ func TestSchemaWatcher_getFileDescriptorSet(t *testing.T) {
 
 func TestSchemaWatcher_FindExtensionByName(t *testing.T) {
 	t.Parallel()
-	resolver, err := newResolver(fakeFileDescriptorSet())
+	_, resolver, err := newResolver(fakeFileDescriptorSet())
 	require.NoError(t, err)
 	schemaWatcher := &SchemaWatcher{
 		resolver: resolver,
@@ -176,7 +176,7 @@ func TestSchemaWatcher_FindExtensionByName(t *testing.T) {
 
 func TestSchemaWatcher_FindExtensionByNumber(t *testing.T) {
 	t.Parallel()
-	resolver, err := newResolver(fakeFileDescriptorSet())
+	_, resolver, err := newResolver(fakeFileDescriptorSet())
 	require.NoError(t, err)
 	schemaWatcher := &SchemaWatcher{
 		resolver: resolver,
@@ -188,7 +188,7 @@ func TestSchemaWatcher_FindExtensionByNumber(t *testing.T) {
 
 func TestSchemaWatcher_FindMessageByName(t *testing.T) {
 	t.Parallel()
-	resolver, err := newResolver(fakeFileDescriptorSet())
+	_, resolver, err := newResolver(fakeFileDescriptorSet())
 	require.NoError(t, err)
 	schemaWatcher := &SchemaWatcher{
 		resolver: resolver,
@@ -200,7 +200,7 @@ func TestSchemaWatcher_FindMessageByName(t *testing.T) {
 
 func TestSchemaWatcher_FindMessageByURL(t *testing.T) {
 	t.Parallel()
-	resolver, err := newResolver(fakeFileDescriptorSet())
+	_, resolver, err := newResolver(fakeFileDescriptorSet())
 	require.NoError(t, err)
 	schemaWatcher := &SchemaWatcher{
 		resolver: resolver,
@@ -232,7 +232,7 @@ func TestSchemaWatcher_updateResolver(t *testing.T) {
 				},
 			},
 		}
-		resolver, err := newResolver(emptySchema)
+		_, resolver, err := newResolver(emptySchema)
 		require.NoError(t, err)
 
 		schemaWatcher := &SchemaWatcher{
@@ -241,7 +241,7 @@ func TestSchemaWatcher_updateResolver(t *testing.T) {
 		}
 		_, err = schemaWatcher.resolver.FindMessageByName("foo.bar.Message")
 		require.Error(t, err, "not found")
-		require.NoError(t, schemaWatcher.updateResolver(context.Background(), false))
+		require.NoError(t, schemaWatcher.updateResolver(context.Background()))
 		got, err := schemaWatcher.resolver.FindMessageByName("foo.bar.Message")
 		require.NoError(t, err)
 		assert.Equal(t, "foo.bar.Message", string(got.Descriptor().FullName()))
@@ -255,7 +255,7 @@ func TestSchemaWatcher_updateResolver(t *testing.T) {
 				},
 			}, "", ""),
 		}
-		err := schemaWatcher.updateResolver(context.Background(), false)
+		err := schemaWatcher.updateResolver(context.Background())
 		require.Error(t, err)
 		assert.EqualError(t, err, "failed to fetch schema: internal: foo")
 	})
@@ -275,7 +275,7 @@ func TestSchemaWatcher_updateResolver(t *testing.T) {
 				},
 			}, "", ""),
 		}
-		err := schemaWatcher.updateResolver(context.Background(), false)
+		err := schemaWatcher.updateResolver(context.Background())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to create resolver from schema:")
 	})


### PR DESCRIPTION
There are a few changes in this PR:
1. Adds support for jitter, to prevent the fixed period from turning many pollers into a thundering herd.
2. In an earlier PR, I added the `fallbackToCache` flag, thinking that only the first attempt to fetch the schema should fallback to the cache. However, I now realize that subsequent ones also should -- because it could be that some other replica of the program was able to poll and store in cache. So by always retrieving from the cache when polling fails, we can make sure that all replicas are using the same schema (vs. some that experienced polling failures getting "stuck" on an older version). So I removed this flag.
3. I've made changes to the notifications to the app: (1) the `OnUpdate` callback is only called when there is actually a change to the schema (determined via testing the old and new `FileDescriptorSet` for equality); and (2) there's a new `OnError` callback to also notify the application of errors.
4. Finally, I've added a `ResolveNow` method on the watcher. I imagine this useful for a dev-env mechanism for telling a program to immediately reload (like triggered via some local build step). I can see ways this could be useful outside of a dev environment, too, such as synchronizing multiple watchers.