### PR TITLE
SchemaWatcher needs to provide a broader interface

### DIFF
--- a/format.go
+++ b/format.go
@@ -18,16 +18,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoregistry"
 )
-
-// Resolver is a Resolver.
-//
-// This is only needed in cases where extensions may be present.
-type Resolver interface {
-	protoregistry.ExtensionTypeResolver
-	protoregistry.MessageTypeResolver
-}
 
 // InputFormat provides the interface to supply the [Converter] with an input
 // composition. The format provided must accept a [Resolver]. Includes

--- a/resolver.go
+++ b/resolver.go
@@ -34,21 +34,7 @@ type Resolver interface {
 	FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumType, error)
 }
 
-// resolver is the interface used by and provided by a *SchemaWatcher, which is
-// intentionally broader than the above interface.
-type resolver interface {
-	Resolver
-	protodesc.Resolver
-
-	// RangeFiles iterates over all registered files while f returns true. The
-	// iteration order is undefined.
-	RangeFiles(f func(protoreflect.FileDescriptor) bool)
-	// RangeFilesByPackage iterates over all registered files in a given proto package
-	// while f returns true. The iteration order is undefined.
-	RangeFilesByPackage(name protoreflect.FullName, f func(protoreflect.FileDescriptor) bool)
-}
-
-type resolverImpl struct {
+type resolver struct {
 	*protoregistry.Files
 	*protoregistry.Types
 }
@@ -58,8 +44,8 @@ type resolverImpl struct {
 // If the input slice is empty, this returns nil
 // The given FileDescriptors must be self-contained, that is they must contain all imports.
 // This can NOT be guaranteed for FileDescriptorSets given over the wire, and can only be guaranteed from builds.
-func newResolver(fileDescriptors *descriptorpb.FileDescriptorSet) (resolver, error) {
-	var r resolverImpl
+func newResolver(fileDescriptors *descriptorpb.FileDescriptorSet) (*resolver, error) {
+	var r resolver
 	// TODO(TCN-925): maybe should reparse unrecognized fields in fileDescriptors after creating resolver?
 	if len(fileDescriptors.File) == 0 {
 		return &r, nil

--- a/resolver.go
+++ b/resolver.go
@@ -1,0 +1,114 @@
+// Copyright 2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prototransform
+
+import (
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// Resolver is used to resolve symbol names and numbers into schema definitions.
+type Resolver interface {
+	protoregistry.ExtensionTypeResolver
+	protoregistry.MessageTypeResolver
+
+	// FindEnumByName looks up an enum by its full name.
+	// E.g., "google.protobuf.Field.Kind".
+	//
+	// This returns (nil, NotFound) if not found.
+	FindEnumByName(enum protoreflect.FullName) (protoreflect.EnumType, error)
+}
+
+// resolver is the interface used by and provided by a *SchemaWatcher, which is
+// intentionally broader than the above interface.
+type resolver interface {
+	Resolver
+	protodesc.Resolver
+
+	// RangeFiles iterates over all registered files while f returns true. The
+	// iteration order is undefined.
+	RangeFiles(f func(protoreflect.FileDescriptor) bool)
+	// RangeFilesByPackage iterates over all registered files in a given proto package
+	// while f returns true. The iteration order is undefined.
+	RangeFilesByPackage(name protoreflect.FullName, f func(protoreflect.FileDescriptor) bool)
+}
+
+type resolverImpl struct {
+	*protoregistry.Files
+	*protoregistry.Types
+}
+
+// newResolver creates a new Resolver.
+//
+// If the input slice is empty, this returns nil
+// The given FileDescriptors must be self-contained, that is they must contain all imports.
+// This can NOT be guaranteed for FileDescriptorSets given over the wire, and can only be guaranteed from builds.
+func newResolver(fileDescriptors *descriptorpb.FileDescriptorSet) (resolver, error) {
+	var r resolverImpl
+	// TODO(TCN-925): maybe should reparse unrecognized fields in fileDescriptors after creating resolver?
+	if len(fileDescriptors.File) == 0 {
+		return &r, nil
+	}
+	files, err := protodesc.FileOptions{AllowUnresolvable: true}.NewFiles(fileDescriptors)
+	if err != nil {
+		return nil, err
+	}
+	r.Files = files
+	r.Types = &protoregistry.Types{}
+	var rangeErr error
+	files.RangeFiles(func(fileDescriptor protoreflect.FileDescriptor) bool {
+		if err := registerTypes(r.Types, fileDescriptor); err != nil {
+			rangeErr = err
+			return false
+		}
+		return true
+	})
+	if rangeErr != nil {
+		return nil, rangeErr
+	}
+	return &r, nil
+}
+
+type typeContainer interface {
+	Enums() protoreflect.EnumDescriptors
+	Messages() protoreflect.MessageDescriptors
+	Extensions() protoreflect.ExtensionDescriptors
+}
+
+func registerTypes(types *protoregistry.Types, container typeContainer) error {
+	for i := 0; i < container.Enums().Len(); i++ {
+		if err := types.RegisterEnum(dynamicpb.NewEnumType(container.Enums().Get(i))); err != nil {
+			return err
+		}
+	}
+	for i := 0; i < container.Messages().Len(); i++ {
+		msg := container.Messages().Get(i)
+		if err := types.RegisterMessage(dynamicpb.NewMessageType(msg)); err != nil {
+			return err
+		}
+		if err := registerTypes(types, msg); err != nil {
+			return err
+		}
+	}
+	for i := 0; i < container.Extensions().Len(); i++ {
+		if err := types.RegisterExtension(dynamicpb.NewExtensionType(container.Extensions().Get(i))); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/schema_watcher.go
+++ b/schema_watcher.go
@@ -62,7 +62,7 @@ type SchemaWatcher struct {
 	errCallback func(error)
 
 	resolverMu      sync.RWMutex
-	resolver        resolver
+	resolver        *resolver
 	resolvedSchema  *descriptorpb.FileDescriptorSet
 	resolveTime     time.Time
 	resolvedVersion string
@@ -159,7 +159,7 @@ func NewSchemaWatcher(ctx context.Context, config *SchemaWatcherConfig) (*Schema
 	return schemaWatcher, nil
 }
 
-func (s *SchemaWatcher) getResolver() resolver {
+func (s *SchemaWatcher) getResolver() *resolver {
 	s.resolverMu.RLock()
 	defer s.resolverMu.RUnlock()
 	return s.resolver

--- a/schema_watcher_test.go
+++ b/schema_watcher_test.go
@@ -211,7 +211,7 @@ func TestSchemaWatcher_FindMessageByURL(t *testing.T) {
 
 func TestSchemaWatcher_getResolver(t *testing.T) {
 	t.Parallel()
-	want := fakeResolver{}
+	want := &resolver{}
 	schemaWatcher := &SchemaWatcher{resolver: want}
 	assert.True(t, schemaWatcher.resolverMu.TryRLock())
 	assert.Equal(t, want, schemaWatcher.getResolver())
@@ -625,10 +625,6 @@ func fakeFileDescriptorSet() *descriptorpb.FileDescriptorSet {
 			},
 		},
 	}
-}
-
-type fakeResolver struct {
-	resolver
 }
 
 type fakeCacheOp struct {

--- a/schema_watcher_test.go
+++ b/schema_watcher_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
@@ -164,7 +163,7 @@ func TestSchemaWatcher_getFileDescriptorSet(t *testing.T) {
 
 func TestSchemaWatcher_FindExtensionByName(t *testing.T) {
 	t.Parallel()
-	_, resolver, err := newResolver(fakeFileDescriptorSet())
+	resolver, err := newResolver(fakeFileDescriptorSet())
 	require.NoError(t, err)
 	schemaWatcher := &SchemaWatcher{
 		resolver: resolver,
@@ -176,7 +175,7 @@ func TestSchemaWatcher_FindExtensionByName(t *testing.T) {
 
 func TestSchemaWatcher_FindExtensionByNumber(t *testing.T) {
 	t.Parallel()
-	_, resolver, err := newResolver(fakeFileDescriptorSet())
+	resolver, err := newResolver(fakeFileDescriptorSet())
 	require.NoError(t, err)
 	schemaWatcher := &SchemaWatcher{
 		resolver: resolver,
@@ -188,7 +187,7 @@ func TestSchemaWatcher_FindExtensionByNumber(t *testing.T) {
 
 func TestSchemaWatcher_FindMessageByName(t *testing.T) {
 	t.Parallel()
-	_, resolver, err := newResolver(fakeFileDescriptorSet())
+	resolver, err := newResolver(fakeFileDescriptorSet())
 	require.NoError(t, err)
 	schemaWatcher := &SchemaWatcher{
 		resolver: resolver,
@@ -200,7 +199,7 @@ func TestSchemaWatcher_FindMessageByName(t *testing.T) {
 
 func TestSchemaWatcher_FindMessageByURL(t *testing.T) {
 	t.Parallel()
-	_, resolver, err := newResolver(fakeFileDescriptorSet())
+	resolver, err := newResolver(fakeFileDescriptorSet())
 	require.NoError(t, err)
 	schemaWatcher := &SchemaWatcher{
 		resolver: resolver,
@@ -232,7 +231,7 @@ func TestSchemaWatcher_updateResolver(t *testing.T) {
 				},
 			},
 		}
-		_, resolver, err := newResolver(emptySchema)
+		resolver, err := newResolver(emptySchema)
 		require.NoError(t, err)
 
 		schemaWatcher := &SchemaWatcher{
@@ -629,26 +628,7 @@ func fakeFileDescriptorSet() *descriptorpb.FileDescriptorSet {
 }
 
 type fakeResolver struct {
-	findExtensionByNameFunc   func(field protoreflect.FullName) (protoreflect.ExtensionType, error)
-	findExtensionByNumberFunc func(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error)
-	findMessageByNameFunc     func(message protoreflect.FullName) (protoreflect.MessageType, error)
-	findMessageByURLFunc      func(url string) (protoreflect.MessageType, error)
-}
-
-func (f fakeResolver) FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error) {
-	return f.findExtensionByNameFunc(field)
-}
-
-func (f fakeResolver) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
-	return f.findExtensionByNumberFunc(message, field)
-}
-
-func (f fakeResolver) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
-	return f.findMessageByNameFunc(message)
-}
-
-func (f fakeResolver) FindMessageByURL(url string) (protoreflect.MessageType, error) {
-	return f.findMessageByURLFunc(url)
+	resolver
 }
 
 type fakeCacheOp struct {


### PR DESCRIPTION
To be useful in other contexts where a schema may be used, the `*SchemaWatcher` type needs to provide a broader API. It currently only provides an API broad enough to satisfy use with marshalers. But many other "schema watching" use cases want to be able to resolve arbitrary descriptors by name and possibly even iterate over all schema elements.

So this adds a few methods to the `*SchemaWatcher`:
* `FindFileByPath`, `FindDescriptorByName`: general-use methods for resolving any symbol or file name.
* `RangeFiles`, `RangeFilesByPackage`: allows for iterating through the entire schema.
* `FindEnumByName`: for completeness and symmetry with existing `FindMessageByName` and `FindExtensionByName` methods.

The `FindDescriptorByName` is the most useful and most versatile, allowing resolving anything, including services and methods.