### PR TITLE
Enable linter in CI and update code to make linter happy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,11 @@ on: push
 permissions:
   contents: read
 jobs:
-  lint:
+  ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.19.x, 1.20.x]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -13,57 +16,21 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
-          check-latest: true
-          cache: true
-      - name: Lint
-        # Often, lint & gofmt guidelines depend on the Go version. To prevent
-        # conflicting guidance, run only on the most recent supported version.
-        # For the same reason, only check generated code on the most recent
-        # supported version.
-        if: matrix.go-version == '1.19.x'
-        run: make lint
-  generate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
+          go-version: ${{ matrix.go-version }}
+      - name: setup-buf
+        uses: bufbuild/buf-setup-action@v1.18.0
+      - name: cache
+        uses: actions/cache@v3
         with:
-          fetch-depth: 0
-      - name: setup-go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.19.x
-          check-latest: true
-          cache: true
-      - uses: bufbuild/buf-setup-action@v1.18.0
-        with:
-          github_token: ${{ github.token }}
-      - name: Generate
-        env:
-          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-connect-ci-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-connect-ci-
+      - name: generate
         run: make generate && make checkgenerate
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: setup-go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.19.x
-          check-latest: true
-          cache: true
-      - uses: bufbuild/buf-setup-action@v1.18.0
-        with:
-          github_token: ${{ github.token }}
-          buf_user: ${{ secrets.BUF_USER }}
-          buf_api_token: ${{ secrets.BUF_TOKEN }}
       - name: test
         env:
-          GOPRIVATE: buf.build/gen/go
-          GONOSUMDB: buf.build/gen/go
           BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
         run: make test
+      - name: lint
+        if: matrix.go-version == '1.20.x'
+        run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
     - cyclop            # covered by gocyclo
     - deadcode          # abandoned
     - exhaustivestruct  # replaced by exhaustruct
+    - exhaustruct       # super-spammy and doesn't like idiomatic Go (especially w/ protos)
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
@@ -38,6 +39,7 @@ linters:
     - maintidx          # covered by gocyclo
     - maligned          # readability trumps efficient struct packing
     - nlreturn          # generous whitespace violates house style
+    - nonamedreturns    # no bare returns is really what we care about
     - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
     - scopelint         # deprecated by author
     - structcheck       # abandoned
@@ -50,3 +52,9 @@ issues:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.
     - "err113: do not define dynamic errors.*"
+    - "variable name 'ok' is too short"
+  exclude-rules:
+    - path: example_test\.go
+      linters:
+        - gocritic
+        - gochecknoglobals

--- a/cache.go
+++ b/cache.go
@@ -35,13 +35,19 @@ type Cache interface {
 	Save(ctx context.Context, key string, data []byte) error
 }
 
-func encodeForCache(schemaID string, syms []string, descriptors *descriptorpb.FileDescriptorSet, version string, ts time.Time) ([]byte, error) {
+func encodeForCache(
+	schemaID string,
+	syms []string,
+	descriptors *descriptorpb.FileDescriptorSet,
+	version string,
+	timestamp time.Time,
+) ([]byte, error) {
 	entry := &prototransformv1alpha1.CacheEntry{
 		Schema: &prototransformv1alpha1.Schema{
 			Descriptors: descriptors,
 			Version:     version,
 		},
-		SchemaTimestamp: timestamppb.New(ts),
+		SchemaTimestamp: timestamppb.New(timestamp),
 		Id:              schemaID,
 		IncludedSymbols: syms,
 	}

--- a/cache/filecache/filecache.go
+++ b/cache/filecache/filecache.go
@@ -91,14 +91,14 @@ func New(config Config) (prototransform.Cache, error) {
 		return nil, fmt.Errorf("%s is not a directory", path)
 	}
 	testFile := filepath.Join(path, ".test")
-	f, err := os.OpenFile(testFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+	file, err := os.OpenFile(testFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {
 		if os.IsPermission(err) {
 			return nil, fmt.Errorf("insufficient permission to create file in %s", path)
 		}
 		return nil, fmt.Errorf("failed to create file in %s: %w", path, err)
 	}
-	closeErr := f.Close()
+	closeErr := file.Close()
 	rmErr := os.Remove(testFile)
 	if closeErr != nil {
 		return nil, closeErr
@@ -129,22 +129,22 @@ func (c *cache) fileNameForKey(key string) string {
 }
 
 func sanitize(s string) string {
-	var sb strings.Builder
-	hexWriter := hex.NewEncoder(&sb)
+	var builder strings.Builder
+	hexWriter := hex.NewEncoder(&builder)
 	var buf [1]byte
 	for i, length := 0, len(s); i < length; i++ {
-		b := s[i]
+		char := s[i]
 		switch {
-		case b >= 'a' && b <= 'z',
-			b >= 'A' && b <= 'Z',
-			b >= '0' && b <= '9',
-			b == '.' || b == '-' || b == '_':
-			sb.WriteByte(b)
+		case char >= 'a' && char <= 'z',
+			char >= 'A' && char <= 'Z',
+			char >= '0' && char <= '9',
+			char == '.' || char == '-' || char == '_':
+			builder.WriteByte(char)
 		default:
-			sb.WriteByte('%')
-			buf[0] = b
+			builder.WriteByte('%')
+			buf[0] = char
 			_, _ = hexWriter.Write(buf[:])
 		}
 	}
-	return sb.String()
+	return builder.String()
 }

--- a/cache/filecache/filecache_test.go
+++ b/cache/filecache/filecache_test.go
@@ -173,11 +173,11 @@ func TestSanitize(t *testing.T) {
 
 func checkFiles(t *testing.T, dir string, mode fs.FileMode, names map[string]struct{}) {
 	t.Helper()
-	err := fs.WalkDir(os.DirFS(dir), ".", func(path string, d fs.DirEntry, err error) error {
+	err := fs.WalkDir(os.DirFS(dir), ".", func(path string, dirEntry fs.DirEntry, err error) error {
 		if !assert.NoError(t, err) {
 			return nil
 		}
-		if d.IsDir() {
+		if dirEntry.IsDir() {
 			if path == "." {
 				return nil
 			}
@@ -189,7 +189,7 @@ func checkFiles(t *testing.T, dir string, mode fs.FileMode, names map[string]str
 			return nil
 		}
 		delete(names, path)
-		info, err := d.Info()
+		info, err := dirEntry.Info()
 		if !assert.NoErrorf(t, err, "failed to get file info for %s", path) {
 			return nil
 		}

--- a/cache/internal/cachetesting/cachetesting.go
+++ b/cache/internal/cachetesting/cachetesting.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint:revive // okay that ctx is second; prefer t to be first
 func RunSimpleCacheTests(t *testing.T, ctx context.Context, cache prototransform.Cache) map[string][]byte {
 	t.Helper()
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestCacheEntryRoundTrip(t *testing.T) {
+	t.Parallel()
 	descriptors := &descriptorpb.FileDescriptorSet{
 		File: []*descriptorpb.FileDescriptorProto{
 			{
@@ -66,41 +67,53 @@ func TestCacheEntryRoundTrip(t *testing.T) {
 func TestIsSuperSet(t *testing.T) {
 	t.Parallel()
 	t.Run("both empty", func(t *testing.T) {
+		t.Parallel()
 		assert.True(t, isSuperSet(nil, nil))
 		assert.True(t, isSuperSet([]string{}, nil))
 		assert.True(t, isSuperSet(nil, make([]string, 0, 10)))
 	})
 	t.Run("superset is empty", func(t *testing.T) {
+		t.Parallel()
 		assert.False(t, isSuperSet(nil, []string{"abc"}))
 	})
 	t.Run("subset is empty", func(t *testing.T) {
+		t.Parallel()
 		assert.False(t, isSuperSet([]string{"abc"}, nil))
 	})
 	t.Run("same", func(t *testing.T) {
+		t.Parallel()
 		assert.True(t, isSuperSet([]string{"abc", "def", "ghi", "xyz"}, []string{"abc", "def", "ghi", "xyz"}))
 	})
 	t.Run("is superset (1)", func(t *testing.T) {
+		t.Parallel()
 		assert.True(t, isSuperSet([]string{"abc", "def", "ghi", "xyz"}, []string{"abc"}))
 	})
 	t.Run("is superset (2)", func(t *testing.T) {
+		t.Parallel()
 		assert.True(t, isSuperSet([]string{"abc", "def", "ghi", "xyz"}, []string{"abc", "ghi"}))
 	})
 	t.Run("is superset (3)", func(t *testing.T) {
+		t.Parallel()
 		assert.True(t, isSuperSet([]string{"abc", "def", "ghi", "xyz"}, []string{"abc", "xyz"}))
 	})
 	t.Run("is superset (4)", func(t *testing.T) {
+		t.Parallel()
 		assert.True(t, isSuperSet([]string{"abc", "def", "ghi", "xyz"}, []string{"xyz"}))
 	})
 	t.Run("is subset (1)", func(t *testing.T) {
+		t.Parallel()
 		assert.False(t, isSuperSet([]string{"abc"}, []string{"abc", "def", "ghi", "xyz"}))
 	})
 	t.Run("is subset (2)", func(t *testing.T) {
+		t.Parallel()
 		assert.False(t, isSuperSet([]string{"abc", "ghi"}, []string{"abc", "def", "ghi", "xyz"}))
 	})
 	t.Run("is subset (3)", func(t *testing.T) {
+		t.Parallel()
 		assert.False(t, isSuperSet([]string{"abc", "xyz"}, []string{"abc", "def", "ghi", "xyz"}))
 	})
 	t.Run("is subset (4)", func(t *testing.T) {
+		t.Parallel()
 		assert.False(t, isSuperSet([]string{"xyz"}, []string{"abc", "def", "ghi", "xyz"}))
 	})
 }

--- a/config.go
+++ b/config.go
@@ -200,7 +200,7 @@ func NewAuthInterceptor(token string) connect.Interceptor {
 
 // BufTokenFromEnvironment returns a token that can be used to download the given module from
 // the BSR by inspecting the BUF_TOKEN environment variable. The given moduleRef can be a full
-// full module reference, with or without a version, or it can just be the domain of the BSR.
+// module reference, with or without a version, or it can just be the domain of the BSR.
 func BufTokenFromEnvironment(moduleRef string) (string, error) {
 	parts := strings.SplitN(moduleRef, "/", 2)
 	envBufToken := os.Getenv("BUF_TOKEN")

--- a/filter_test.go
+++ b/filter_test.go
@@ -24,43 +24,48 @@ import (
 )
 
 func TestRedact(t *testing.T) {
+	t.Parallel()
 	t.Run("RedactedMessage", func(t *testing.T) {
-		in := &foov1.RedactedMessage{
+		t.Parallel()
+		input := &foov1.RedactedMessage{
 			Name: "sensitiveInformation",
 		}
-		got := Redact(removeSensitiveData())(in.ProtoReflect())
+		got := Redact(removeSensitiveData())(input.ProtoReflect())
 		want := &foov1.RedactedMessage{}
 		assert.True(t, proto.Equal(want, got.Interface()))
 	})
 	t.Run("RedactedMessageField", func(t *testing.T) {
-		in := &foov1.RedactedMessageField{
+		t.Parallel()
+		input := &foov1.RedactedMessageField{
 			Name: &foov1.RedactedMessage{
 				Name: "sensitiveInformation",
 			},
 		}
-		got := Redact(removeSensitiveData())(in.ProtoReflect())
+		got := Redact(removeSensitiveData())(input.ProtoReflect())
 		want := &foov1.RedactedMessageField{
 			Name: &foov1.RedactedMessage{},
 		}
 		assert.True(t, proto.Equal(want, got.Interface()))
 	})
 	t.Run("RedactedRepeatedField", func(t *testing.T) {
-		in := &foov1.RedactedRepeatedField{
+		t.Parallel()
+		input := &foov1.RedactedRepeatedField{
 			Name: []string{"sensitiveInformation"},
 		}
-		got := Redact(removeSensitiveData())(in.ProtoReflect())
+		got := Redact(removeSensitiveData())(input.ProtoReflect())
 		want := &foov1.RedactedRepeatedField{}
 		assert.True(t, proto.Equal(want, got.Interface()))
 	})
 	t.Run("RedactedMap", func(t *testing.T) {
-		in := &foov1.RedactedMap{
+		t.Parallel()
+		input := &foov1.RedactedMap{
 			Name: map[string]*foov1.RedactedMessage{
 				"foo": {
 					Name: "sensitiveInformation",
 				},
 			},
 		}
-		got := Redact(removeSensitiveData())(in.ProtoReflect())
+		got := Redact(removeSensitiveData())(input.ProtoReflect())
 		want := &foov1.RedactedMap{
 			Name: map[string]*foov1.RedactedMessage{
 				"foo": {},
@@ -69,39 +74,43 @@ func TestRedact(t *testing.T) {
 		assert.True(t, proto.Equal(want, got.Interface()))
 	})
 	t.Run("RedactedOneOf", func(t *testing.T) {
-		in := &foov1.RedactedOneOf{
+		t.Parallel()
+		input := &foov1.RedactedOneOf{
 			OneofField: &foov1.RedactedOneOf_Foo1{Foo1: 64},
 		}
-		got := Redact(removeSensitiveData())(in.ProtoReflect())
+		got := Redact(removeSensitiveData())(input.ProtoReflect())
 		want := &foov1.RedactedOneOf{}
 		assert.True(t, proto.Equal(want, got.Interface()))
 	})
 	t.Run("RedactedEnum", func(t *testing.T) {
-		in := &foov1.RedactedEnum{
+		t.Parallel()
+		input := &foov1.RedactedEnum{
 			Name: foov1.Enum_ENUM_FIRST,
 		}
-		got := Redact(removeSensitiveData())(in.ProtoReflect())
+		got := Redact(removeSensitiveData())(input.ProtoReflect())
 		want := &foov1.RedactedEnum{}
 		assert.True(t, proto.Equal(want, got.Interface()))
 	})
 	t.Run("RedactedRepeatedEnum", func(t *testing.T) {
-		in := &foov1.RedactedRepeatedEnum{
+		t.Parallel()
+		input := &foov1.RedactedRepeatedEnum{
 			Name: []foov1.Enum{
 				foov1.Enum_ENUM_FIRST,
 				foov1.Enum_ENUM_SECOND,
 				foov1.Enum_ENUM_THIRD,
 			},
 		}
-		got := Redact(removeSensitiveData())(in.ProtoReflect())
+		got := Redact(removeSensitiveData())(input.ProtoReflect())
 		want := &foov1.RedactedRepeatedEnum{}
 		assert.True(t, proto.Equal(want, got.Interface()))
 	})
 	t.Run("NotRedactedField", func(t *testing.T) {
-		in := &foov1.NotRedactedField{
+		t.Parallel()
+		input := &foov1.NotRedactedField{
 			Name: "NotSensitiveData",
 		}
-		got := Redact(removeSensitiveData())(in.ProtoReflect())
-		assert.True(t, proto.Equal(in, got.Interface()))
+		got := Redact(removeSensitiveData())(input.ProtoReflect())
+		assert.True(t, proto.Equal(input, got.Interface()))
 	})
 }
 

--- a/jitter.go
+++ b/jitter.go
@@ -24,7 +24,7 @@ import (
 // We create our own locked RNG so we won't have lock contention with the global
 // RNG that package "math/rand" creates. Also, that way we are not at the mercy
 // of other packages that might be seeding "math/rand"'s global RNG in a bad way.
-var rnd = newLockedRand()
+var rnd = newLockedRand() //nolint:gochecknoglobals
 
 func addJitter(period time.Duration, jitter float64) time.Duration {
 	factor := (rnd.Float64()*2 - 1) * jitter // produces a number between -jitter and jitter
@@ -54,6 +54,7 @@ func (s *lockedSource) Seed(seed int64) {
 }
 
 func newLockedRand() *rand.Rand {
+	//nolint:gosec // don't need secure RNG for this and prefer something that can't exhaust entropy
 	return rand.New(&lockedSource{src: rand.NewSource(int64(seed()))})
 }
 

--- a/jitter_test.go
+++ b/jitter_test.go
@@ -57,14 +57,14 @@ func TestAddJitter(t *testing.T) {
 			t.Parallel()
 			var min, max time.Duration
 			for i := 0; i < 10_000; i++ {
-				p := addJitter(testCase.pollingPeriod, testCase.jitter)
-				require.GreaterOrEqual(t, p, testCase.min)
-				require.LessOrEqual(t, p, testCase.max)
-				if i == 0 || p < min {
-					min = p
+				period := addJitter(testCase.pollingPeriod, testCase.jitter)
+				require.GreaterOrEqual(t, period, testCase.min)
+				require.LessOrEqual(t, period, testCase.max)
+				if i == 0 || period < min {
+					min = period
 				}
-				if i == 0 || p > max {
-					max = p
+				if i == 0 || period > max {
+					max = period
 				}
 			}
 			// After 10k iterations, with uniform distribution RNG, we could

--- a/resolver.go
+++ b/resolver.go
@@ -45,20 +45,20 @@ type resolver struct {
 // The given FileDescriptors must be self-contained, that is they must contain all imports.
 // This can NOT be guaranteed for FileDescriptorSets given over the wire, and can only be guaranteed from builds.
 func newResolver(fileDescriptors *descriptorpb.FileDescriptorSet) (*resolver, error) {
-	var r resolver
+	var result resolver
 	// TODO(TCN-925): maybe should reparse unrecognized fields in fileDescriptors after creating resolver?
 	if len(fileDescriptors.File) == 0 {
-		return &r, nil
+		return &result, nil
 	}
 	files, err := protodesc.FileOptions{AllowUnresolvable: true}.NewFiles(fileDescriptors)
 	if err != nil {
 		return nil, err
 	}
-	r.Files = files
-	r.Types = &protoregistry.Types{}
+	result.Files = files
+	result.Types = &protoregistry.Types{}
 	var rangeErr error
 	files.RangeFiles(func(fileDescriptor protoreflect.FileDescriptor) bool {
-		if err := registerTypes(r.Types, fileDescriptor); err != nil {
+		if err := registerTypes(result.Types, fileDescriptor); err != nil {
 			rangeErr = err
 			return false
 		}
@@ -67,7 +67,7 @@ func newResolver(fileDescriptors *descriptorpb.FileDescriptorSet) (*resolver, er
 	if rangeErr != nil {
 		return nil, rangeErr
 	}
-	return &r, nil
+	return &result, nil
 }
 
 type typeContainer interface {


### PR DESCRIPTION
When the CI config for this repo was created, the linter was not correctly enabled. It had an `if` condition that referenced a property that didn't actually exist because CI wasn't setup at the time to use a matrix of Go versions.

I've reformulated it to look more standard (modeled after the CI config for the `connect-go` repo). I also had a lot of lint errors to address in the codebase to make it happy.