### PR TITLE
Fix errant callback and add test

### DIFF
--- a/schema_watcher.go
+++ b/schema_watcher.go
@@ -178,7 +178,7 @@ func (s *SchemaWatcher) updateResolver(ctx context.Context) (err error) {
 					defer s.callbackMu.Unlock()
 					s.callback()
 				}()
-			} else if !errors.Is(err, ErrSchemaNotModified) && s.errCallback != nil {
+			} else if err != nil && !errors.Is(err, ErrSchemaNotModified) && s.errCallback != nil {
 				go func() {
 					s.callbackMu.Lock()
 					defer s.callbackMu.Unlock()

--- a/schema_watcher_test.go
+++ b/schema_watcher_test.go
@@ -592,7 +592,6 @@ func TestSchemaWatcher_callbacks(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatalf("schema poller not invoked expected number of times; want 5, got %d", count.Load())
 	}
-	// initial resolution
 	var notice string
 	getNextNotice := func() {
 		select {
@@ -602,7 +601,7 @@ func TestSchemaWatcher_callbacks(t *testing.T) {
 		}
 	}
 	getNextNotice()
-	require.Equal(t, "update: Message", notice)
+	require.Equal(t, "update: Message", notice) // initial resolution
 	getNextNotice()
 	require.Equal(t, "error: failed to fetch schema: internal: no descriptors to return", notice)
 	getNextNotice()


### PR DESCRIPTION
I began to integrate this into the knitgateway and saw an issue while testing. The `OnError` callback was getting called with a `nil` error -- oops! This fixes that bug and also adds a test that the `SchemaWatcher` delivers callbacks as expected.