### PR TITLE
Add API for accessing underlying FileDescriptorSet

### DIFF
--- a/schema_watcher.go
+++ b/schema_watcher.go
@@ -489,6 +489,16 @@ func (s *SchemaWatcher) FindEnumByName(enum protoreflect.FullName) (protoreflect
 	return res.FindEnumByName(enum)
 }
 
+// ResolvedSchema returns the resolved schema in the form of a
+// FileDescriptorSet. Until AwaitReady returns a non-nil status, the return
+// value of this function can be nil.
+func (s *SchemaWatcher) ResolvedSchema() *descriptorpb.FileDescriptorSet {
+	s.resolverMu.RLock()
+	schema := s.resolvedSchema
+	s.resolverMu.RUnlock()
+	return schema
+}
+
 func (s *SchemaWatcher) start(ctx context.Context, pollingPeriod time.Duration, jitter float64) {
 	go func() {
 		if !s.initialUpdateResolver(ctx, pollingPeriod, jitter) {

--- a/schema_watcher.go
+++ b/schema_watcher.go
@@ -492,6 +492,9 @@ func (s *SchemaWatcher) FindEnumByName(enum protoreflect.FullName) (protoreflect
 // ResolvedSchema returns the resolved schema in the form of a
 // FileDescriptorSet. Until AwaitReady returns a non-nil status, the return
 // value of this function can be nil.
+// The caller must not mutate the returned file descriptor set. Clone the
+// returned file descriptor set using proto.Clone before performing mutations
+// on it.
 func (s *SchemaWatcher) ResolvedSchema() *descriptorpb.FileDescriptorSet {
 	s.resolverMu.RLock()
 	schema := s.resolvedSchema

--- a/schema_watcher_test.go
+++ b/schema_watcher_test.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"buf.build/gen/go/bufbuild/reflect/bufbuild/connect-go/buf/reflect/v1beta1/reflectv1beta1connect"
-	"buf.build/gen/go/bufbuild/reflect/protocolbuffers/go/buf/reflect/v1beta1"
+	reflectv1beta1 "buf.build/gen/go/bufbuild/reflect/protocolbuffers/go/buf/reflect/v1beta1"
 	"github.com/bufbuild/connect-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -367,6 +367,7 @@ func TestSchemaWatcher_AwaitReady(t *testing.T) {
 		require.True(t, errors.Is(err, context.DeadlineExceeded))
 		ok, _ := watcher.LastResolved()
 		require.False(t, ok)
+		require.Nil(t, watcher.ResolvedSchema())
 
 		timestamp := time.Now()
 		close(latch)
@@ -377,6 +378,7 @@ func TestSchemaWatcher_AwaitReady(t *testing.T) {
 		ok, resolvedTime := watcher.LastResolved()
 		require.True(t, ok)
 		require.False(t, resolvedTime.Before(timestamp))
+		require.NotNil(t, watcher.ResolvedSchema())
 	})
 	t.Run("errors before becoming ready", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
The `protoreflect` APIs offer no way to go back to the underlying protobuf descriptor messages even though there are many circumstances where that can be useful. Therefore, this PR introduces an API to access the raw descriptor.