### PR TITLE
Improve callback signature

### DIFF
--- a/config.go
+++ b/config.go
@@ -74,11 +74,11 @@ type SchemaWatcherConfig struct {
 	// OnUpdate is an optional callback that will be invoked when a new schema
 	// is fetched. This can be used by an application to take action when a new
 	// schema becomes available.
-	OnUpdate func()
+	OnUpdate func(*SchemaWatcher)
 	// OnError is an optional callback that will be invoked when a schema cannot
 	// be fetched. This could be due to the SchemaPoller returning an error or
 	// failure to convert the fetched descriptors into a resolver.
-	OnError func(error)
+	OnError func(*SchemaWatcher, error)
 }
 
 func (c *SchemaWatcherConfig) validate() error {

--- a/schema_watcher.go
+++ b/schema_watcher.go
@@ -59,8 +59,8 @@ type SchemaWatcher struct {
 	cache   Cache
 
 	callbackMu  sync.Mutex
-	callback    func()
-	errCallback func(error)
+	callback    func(*SchemaWatcher)
+	errCallback func(*SchemaWatcher, error)
 
 	resolverMu      sync.RWMutex
 	resolver        *resolver
@@ -188,13 +188,13 @@ func (s *SchemaWatcher) updateResolver(ctx context.Context) (err error) {
 					// means callback does not need to be thread-safe.
 					s.callbackMu.Lock()
 					defer s.callbackMu.Unlock()
-					s.callback()
+					s.callback(s)
 				}()
 			} else if err != nil && !errors.Is(err, ErrSchemaNotModified) && s.errCallback != nil {
 				go func() {
 					s.callbackMu.Lock()
 					defer s.callbackMu.Unlock()
-					s.errCallback(err)
+					s.errCallback(s, err)
 				}()
 			}
 		}()


### PR DESCRIPTION
This is technically a breaking change, but I think it's important for usability, and trivial for users of the library to update their code if this breaks them. Also, this library has not yet reached v1.0, so I think this is the time to make improvements like this.

This adds a `*SchemaWatcher` param to callbacks, which avoids atomic pointer shenanigans (like those seen in `schema_watcher_test.go`).

This should make the callbacks more useful. If a callback wants to interact with the updated results (which seems likely), it was previously needlessly complicated to do so. This also makes it trivial to watch multiple schemas, wired up to a single notification mechanism.