### PR TITLE
Update build tools to latest versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x, 1.21.x]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -32,5 +32,5 @@ jobs:
           BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
         run: make test
       - name: lint
-        if: matrix.go-version == '1.20.x'
+        if: matrix.go-version == '1.21.x'
         run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
   disable:
     - cyclop            # covered by gocyclo
     - deadcode          # abandoned
+    - depguard          # requires custom config in newer versions to use non-stdlib deps
     - exhaustivestruct  # replaced by exhaustruct
     - exhaustruct       # super-spammy and doesn't like idiomatic Go (especially w/ protos)
     - funlen            # rely on code review to limit function length

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ COPYRIGHT_YEARS := 2023
 LICENSE_IGNORE := -e internal/testdata/
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
 GO ?= go
+BUF_VERSION ?= v1.26.1
+GOLANGCI_LINT_VERSION ?= v1.54.1
 
 .PHONY: help
 help: ## Describe useful make targets
@@ -76,13 +78,13 @@ checkgenerate:
 
 $(BIN)/buf: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@v1.12.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION)
 
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
 	GOBIN=$(abspath $(@D)) $(GO) install \
-		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.12.0
+		  github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@$(BUF_VERSION)
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/prototransform
 
-go 1.19
+go 1.20
 
 require (
 	buf.build/gen/go/bufbuild/reflect/connectrpc/go v1.11.0-20230627113514-3943db27b83c.1

--- a/schema_watcher.go
+++ b/schema_watcher.go
@@ -568,11 +568,11 @@ func (s *SchemaWatcher) getFileDescriptorSet(ctx context.Context) (*descriptorpb
 		// try to fallback to cache
 		data, cacheErr := s.cache.Load(ctx, s.cacheKey)
 		if cacheErr != nil {
-			return nil, "", time.Time{}, fmt.Errorf("%w (failed to load from cache: %v)", err, cacheErr)
+			return nil, "", time.Time{}, fmt.Errorf("%w (failed to load from cache: %w)", err, cacheErr)
 		}
 		msg, cacheErr := decodeForCache(data)
 		if cacheErr != nil {
-			return nil, "", time.Time{}, fmt.Errorf("%w (failed to decode cached value: %v)", err, cacheErr)
+			return nil, "", time.Time{}, fmt.Errorf("%w (failed to decode cached value: %w)", err, cacheErr)
 		}
 		if !isCorrectCacheEntry(msg, s.schemaID, s.includeSymbols) {
 			// Cache key collision! Do not use this result!


### PR DESCRIPTION
Update buf and golangci-lint to the latest versions. Update the CI workflow to run tests on Go 1.20 and 1.21. Fix a lint warning with error wrapping (now that multiple errors are supported in Go 1.20+).