### PR TITLE
Update to go1.21 and golangci 1.60.0, test with go1.23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.21.x, 1.22.x, 1.23.x]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -32,5 +32,5 @@ jobs:
           BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
         run: make test
       - name: lint
-        if: matrix.go-version == '1.22.x'
+        if: matrix.go-version == '1.23.x'
         run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,34 +17,27 @@ linters-settings:
       - T any
       - i int
       - wg sync.WaitGroup
+      - ok bool
 linters:
   enable-all: true
   disable:
     - cyclop            # covered by gocyclo
-    - deadcode          # abandoned
     - depguard          # requires custom config in newer versions to use non-stdlib deps
-    - exhaustivestruct  # replaced by exhaustruct
+    - execinquery       # deprecated in golangci v1.58.0
     - exhaustruct       # super-spammy and doesn't like idiomatic Go (especially w/ protos)
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - golint            # deprecated by Go team
     - gomnd             # some unnamed constants are okay
-    - ifshort           # deprecated by author
     - inamedparam       # convention is not followed
-    - interfacer        # deprecated by author
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo
-    - maligned          # readability trumps efficient struct packing
+    - mnd               # some unnamed constants are okay
     - nlreturn          # generous whitespace violates house style
     - nonamedreturns    # no bare returns is really what we care about
-    - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
-    - scopelint         # deprecated by author
-    - structcheck       # abandoned
     - testpackage       # internal tests are fine
-    - varcheck          # abandoned
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
 issues:
@@ -52,8 +45,7 @@ issues:
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.
-    - "err113: do not define dynamic errors.*"
-    - "variable name 'ok' is too short"
+    - "do not define dynamic errors.*"
   exclude-rules:
     - path: example_test\.go
       linters:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ LICENSE_IGNORE := -e internal/testdata/
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
 GO ?= go
 BUF_VERSION ?= v1.29.0
-GOLANGCI_LINT_VERSION ?= v1.57.1
+GOLANGCI_LINT_VERSION ?= v1.60.0
 
 .PHONY: help
 help: ## Describe useful make targets

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/prototransform
 
-go 1.20
+go 1.21
 
 require (
 	buf.build/gen/go/bufbuild/reflect/connectrpc/go v1.16.2-20240117202343-bf8f65e8876c.1

--- a/jitter_test.go
+++ b/jitter_test.go
@@ -55,16 +55,16 @@ func TestAddJitter(t *testing.T) {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			var min, max time.Duration
+			var minPeriod, maxPeriod time.Duration
 			for i := 0; i < 10_000; i++ {
 				period := addJitter(testCase.pollingPeriod, testCase.jitter)
 				require.GreaterOrEqual(t, period, testCase.min)
 				require.LessOrEqual(t, period, testCase.max)
-				if i == 0 || period < min {
-					min = period
+				if i == 0 || period < minPeriod {
+					minPeriod = period
 				}
-				if i == 0 || period > max {
-					max = period
+				if i == 0 || period > maxPeriod {
+					maxPeriod = period
 				}
 			}
 			// After 10k iterations, with uniform distribution RNG, we could
@@ -72,7 +72,7 @@ func TestAddJitter(t *testing.T) {
 			// to make sure we don't see flaky failures in CI. We want to observe
 			// at least 90% of the effective jitter range.
 			minVariation := time.Duration(0.9 * float64(testCase.max-testCase.min))
-			require.GreaterOrEqual(t, max-min, minVariation)
+			require.GreaterOrEqual(t, maxPeriod-minPeriod, minVariation)
 		})
 	}
 }


### PR DESCRIPTION
Now that go 1.23 is out, we can update this repo to no longer support go 1.20.